### PR TITLE
Better error message when opening SIARD 2.0 file

### DIFF
--- a/src/ch/admin/bar/siard2/api/Archive.java
+++ b/src/ch/admin/bar/siard2/api/Archive.java
@@ -27,6 +27,8 @@ public interface Archive
   public static final String sSIARD_DEFAULT_EXTENSION = "siard";
   /** the oldest version of the meta data XSD still supported for reading */
   public static final String sMETA_DATA_VERSION_1_0 = "1.0";
+  /** the abrogated version of the meta data XSD (unsupported) */
+  public static final String sMETA_DATA_VERSION_2_0 = "2.0";
   /** the current version of the meta data XSD */
   public static final String sMETA_DATA_VERSION = "2.1";
   /** default maximum string size for inlining LOBs */

--- a/src/ch/admin/bar/siard2/api/primary/ArchiveImpl.java
+++ b/src/ch/admin/bar/siard2/api/primary/ArchiveImpl.java
@@ -22,7 +22,9 @@ public class ArchiveImpl
   private static final String _sCONTENT_FOLDER = "content/";
   public static String getContentFolder() { return _sCONTENT_FOLDER; }
   private static final String _sSIARDVERSION_FOLDER = "siardversion/";
+  private static final String _sSIARDVERSION_FOLDER_2_0 = "version/";
   public static String getSiardVersionFolder() { return _sHEADER_FOLDER+_sSIARDVERSION_FOLDER+Archive.sMETA_DATA_VERSION+"/"; }
+  public static String getSiardVersionFolder20() { return _sHEADER_FOLDER+_sSIARDVERSION_FOLDER_2_0+Archive.sMETA_DATA_VERSION_2_0+"/"; }
   private static final String _sMETADATA_XML = "metadata.xml";
   public static String getMetaDataXml() { return _sHEADER_FOLDER+_sMETADATA_XML; }
   private static final String _sMETADATA_XSD = "metadata.xsd";
@@ -305,12 +307,19 @@ public class ArchiveImpl
     if (feMetaData != null)
     {
       SiardArchive sa = null;
+      // format version 2.1
       if (existsFolderEntry(getSiardVersionFolder()))
       {
         InputStream isMetaData = openFileEntry(getMetaDataXml());
         sa = MetaDataXml.readXml(isMetaData);
         isMetaData.close();
       }
+      // format version 2.0 (abrogated)
+      else if (existsFolderEntry(getSiardVersionFolder20()))
+      {
+        throw new IOException("Unsupported SIARD format version 2.0!");
+      }
+      // format version 1.0
       else
       {
         InputStream isMetaData = openFileEntry(getMetaDataXml());


### PR DESCRIPTION
Files with SIARD format version 2.0 cannot be opened with SiardGui. It fails with an IOException with error message "Invalid SIARD meta data!" which is a little imprecise. This PR changes the error message to "Unsupported SIARD format version 2.0!".