### PR TITLE
fix: java 17 compatible xml element lookup

### DIFF
--- a/src/main/java/ch/admin/bar/siard2/api/primary/TableImpl.java
+++ b/src/main/java/ch/admin/bar/siard2/api/primary/TableImpl.java
@@ -282,7 +282,7 @@ public class TableImpl
                 InputStream isXsdTable = ArchiveImpl.class.getResourceAsStream(Archive.sSIARD2_GENERIC_TABLE_XSD_RESOURCE);
                 Document doc = getDocumentBuilder().parse(isXsdTable);
 
-                Element elAny = (Element) doc.getElementsByTagName("xs:any")
+                Element elAny = (Element) doc.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "any")
                         .item(0);
                 Element elSequence = (Element) elAny.getParentNode();
                 XU.clearElement(elSequence);


### PR DESCRIPTION
Java 8 seems to have had more lenient parsing of `getElementsByTagName("xs:any")`
Fix for SiardCmd Java 17 migration: https://github.com/sfa-siard/SiardCmd/pull/71