### PR TITLE
fix: create elements in parent namespace

### DIFF
--- a/src/main/java/ch/admin/bar/siard2/api/primary/TableImpl.java
+++ b/src/main/java/ch/admin/bar/siard2/api/primary/TableImpl.java
@@ -61,7 +61,7 @@ public class TableImpl
             throws IOException {
         try {
             if (_db == null) {
-                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance(); // TODO: may be cause of error after java17 upgrade
                 dbf.setNamespaceAware(true);
                 _db = dbf.newDocumentBuilder();
             }
@@ -77,7 +77,7 @@ public class TableImpl
             throws IOException {
         try {
             if (_trans == null) {
-                TransformerFactory tf = TransformerFactory.newInstance();
+                TransformerFactory tf = TransformerFactory.newInstance(); // TODO: may be cause of error after java17 upgrade
                 _trans = tf.newTransformer();
                 _trans.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
                 _trans.setOutputProperty(OutputKeys.METHOD, "xml");
@@ -282,7 +282,7 @@ public class TableImpl
                 InputStream isXsdTable = ArchiveImpl.class.getResourceAsStream(Archive.sSIARD2_GENERIC_TABLE_XSD_RESOURCE);
                 Document doc = getDocumentBuilder().parse(isXsdTable);
 
-                Element elAny = (Element) doc.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "any")
+                Element elAny = (Element) doc.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "any") // TODO: may be cause of error after java17 upgrade
                         .item(0);
                 Element elSequence = (Element) elAny.getParentNode();
                 XU.clearElement(elSequence);

--- a/src/main/java/ch/admin/bar/siard2/api/primary/TableImpl.java
+++ b/src/main/java/ch/admin/bar/siard2/api/primary/TableImpl.java
@@ -21,6 +21,7 @@ import ch.enterag.utils.DU;
 import ch.enterag.utils.SU;
 import ch.enterag.utils.background.Progress;
 import ch.enterag.utils.xml.XU;
+import lombok.SneakyThrows;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
@@ -57,16 +58,12 @@ public class TableImpl
 
     static DocumentBuilder _db = null;
 
-    static DocumentBuilder getDocumentBuilder()
-            throws IOException {
-        try {
-            if (_db == null) {
-                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance(); // TODO: may be cause of error after java17 upgrade
-                dbf.setNamespaceAware(true);
-                _db = dbf.newDocumentBuilder();
-            }
-        } catch (ParserConfigurationException pce) {
-            throw new IOException("DocumentBuilder could not be created!", pce);
+    @SneakyThrows
+    static DocumentBuilder getDocumentBuilder() throws IOException {
+        if (_db == null) {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance(); // TODO: may be cause of error after java17 upgrade
+            dbf.setNamespaceAware(true);
+            _db = dbf.newDocumentBuilder();
         }
         return _db;
     }
@@ -150,8 +147,8 @@ public class TableImpl
     private void addElement(Element elParent, String sTag, MetaValue mv, boolean bNullable)
             throws IOException {
         Document doc = elParent.getOwnerDocument();
-        // Element elElement = doc.createElementNS(elParent.getNamespaceURI(),"xs:element");
-        Element elElement = doc.createElement("xs:element");
+        // create the element with the same namespace as the parent (XML Schema namespace)
+        Element elElement = doc.createElementNS(elParent.getNamespaceURI(), "xs:element");
         elParent.appendChild(elElement);
         elElement.setAttribute("name", sTag);
         int iPreType = mv.getPreType();
@@ -238,12 +235,12 @@ public class TableImpl
         } else {
             elElement.setAttribute("minOccurs", "0");
 
-            //Element elComplexType = doc.createElementNS(elElement.getNamespaceURI(),"xs:complexType");
-            Element elComplexType = doc.createElement("xs:complexType");
+            // create complexType in the XML Schema namespace
+            Element elComplexType = doc.createElementNS(elElement.getNamespaceURI(), "xs:complexType");
             elElement.appendChild(elComplexType);
 
-            //Element elSequence = doc.createElementNS(elComplexType.getNamespaceURI(),"xs:sequence");
-            Element elSequence = doc.createElement("xs:sequence");
+            // create sequence in the XML Schema namespace
+            Element elSequence = doc.createElementNS(elComplexType.getNamespaceURI(), "xs:sequence");
             elComplexType.appendChild(elSequence);
 
             for (int iField = 0; iField < mv.getMetaFields(); iField++) {

--- a/src/main/java/ch/admin/bar/siard2/api/primary/TableImpl.java
+++ b/src/main/java/ch/admin/bar/siard2/api/primary/TableImpl.java
@@ -61,7 +61,7 @@ public class TableImpl
     @SneakyThrows
     static DocumentBuilder getDocumentBuilder() throws IOException {
         if (_db == null) {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance(); // TODO: may be cause of error after java17 upgrade
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setNamespaceAware(true);
             _db = dbf.newDocumentBuilder();
         }
@@ -74,7 +74,7 @@ public class TableImpl
             throws IOException {
         try {
             if (_trans == null) {
-                TransformerFactory tf = TransformerFactory.newInstance(); // TODO: may be cause of error after java17 upgrade
+                TransformerFactory tf = TransformerFactory.newInstance();
                 _trans = tf.newTransformer();
                 _trans.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
                 _trans.setOutputProperty(OutputKeys.METHOD, "xml");
@@ -279,7 +279,7 @@ public class TableImpl
                 InputStream isXsdTable = ArchiveImpl.class.getResourceAsStream(Archive.sSIARD2_GENERIC_TABLE_XSD_RESOURCE);
                 Document doc = getDocumentBuilder().parse(isXsdTable);
 
-                Element elAny = (Element) doc.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "any") // TODO: may be cause of error after java17 upgrade
+                Element elAny = (Element) doc.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "any")
                         .item(0);
                 Element elSequence = (Element) elAny.getParentNode();
                 XU.clearElement(elSequence);

--- a/src/test/java/ch/admin/bar/siard2/api/primary/TableSchemaTester.java
+++ b/src/test/java/ch/admin/bar/siard2/api/primary/TableSchemaTester.java
@@ -487,9 +487,9 @@ public class TableSchemaTester {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             DocumentBuilder db = dbf.newDocumentBuilder();
             Document doc = db.parse(isXsdTable);
-            
+
             Element elAny = (Element) doc.getElementsByTagName("xs:any")
-                                         .item(0);
+                                         .item(0);  // TODO: may be cause of error after java17 upgrade
             Element elSequence = (Element) elAny.getParentNode();
             for (int i = elSequence.getChildNodes()
                                    .getLength() - 1; i >= 0; i--) {


### PR DESCRIPTION
This addresses issue #16 

The previously used documentBuilder (produced from com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl) allowed elements to be created without a namespace.

This class is not available in Java9+ (since it's internal). Changing it to `javax.xml.parsers.DocumentBuilder` caused an empty element `xmlns=""` to be injected, because it is less permissive than the xerces one that allows elements to be added without a namespace.

Creating the elements in their parents namespace fixes the problem: No `xmlns=""` is injected, because the parent namespace is used.